### PR TITLE
hide password by default

### DIFF
--- a/app/views/install/db_config.blade.php
+++ b/app/views/install/db_config.blade.php
@@ -16,7 +16,7 @@
             </tr>
             <tr>
                 <th scope="row"><label for="password">Password</label></th>
-                <td><input name="DB_PASSWORD" id="password" type="text" size="25" value="root" /></td>
+                <td><input name="DB_PASSWORD" id="password" type="password" size="25" value="" /></td>
                 <td>&hellip;and your MySQL password.</td>
             </tr>
             <tr>


### PR DESCRIPTION
I think you should use a proper password field, otherwise some auto fill plugins will save our password and people watching us installing doptor can see it too..
