### PR TITLE
Moved the development dependency way/generators to local configuration

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -113,7 +113,6 @@ return array(
 		'Intervention\Image\ImageServiceProvider',
 		'Menu\MenuServiceProvider',
 		'Barryvdh\DomPDF\ServiceProvider',
-		'Way\Generators\GeneratorsServiceProvider',
 	),
 
 	/*

--- a/app/config/local/app.php
+++ b/app/config/local/app.php
@@ -1,0 +1,43 @@
+<?php
+
+return array(
+
+    'providers' => array(
+
+        'Illuminate\Foundation\Providers\ArtisanServiceProvider',
+        'Illuminate\Auth\AuthServiceProvider',
+        'Illuminate\Cache\CacheServiceProvider',
+        'Illuminate\Session\CommandsServiceProvider',
+        'Illuminate\Foundation\Providers\ConsoleSupportServiceProvider',
+        'Illuminate\Routing\ControllerServiceProvider',
+        'Illuminate\Cookie\CookieServiceProvider',
+        'Illuminate\Database\DatabaseServiceProvider',
+        'Illuminate\Encryption\EncryptionServiceProvider',
+        'Illuminate\Filesystem\FilesystemServiceProvider',
+        'Illuminate\Hashing\HashServiceProvider',
+        'Illuminate\Html\HtmlServiceProvider',
+        'Illuminate\Log\LogServiceProvider',
+        'Illuminate\Mail\MailServiceProvider',
+        'Illuminate\Database\MigrationServiceProvider',
+        'Illuminate\Pagination\PaginationServiceProvider',
+        'Illuminate\Queue\QueueServiceProvider',
+        'Illuminate\Redis\RedisServiceProvider',
+        'Illuminate\Remote\RemoteServiceProvider',
+        'Illuminate\Auth\Reminders\ReminderServiceProvider',
+        'Illuminate\Database\SeedServiceProvider',
+        'Illuminate\Session\SessionServiceProvider',
+        'Illuminate\Translation\TranslationServiceProvider',
+        'Illuminate\Validation\ValidationServiceProvider',
+        'Illuminate\View\ViewServiceProvider',
+        'Illuminate\Workbench\WorkbenchServiceProvider',
+
+        'Cartalyst\Sentry\SentryServiceProvider',
+        'Creolab\LaravelModules\ServiceProvider',
+        'Robbo\Presenter\PresenterServiceProvider',
+        'Intervention\Image\ImageServiceProvider',
+        'Menu\MenuServiceProvider',
+        'Barryvdh\DomPDF\ServiceProvider',
+        'Way\Generators\GeneratorsServiceProvider',
+
+    ),
+);


### PR DESCRIPTION
The dependency `way/generators` was moved from the production environment to local environment as it is used only during development.
P.S. The PHP version doesn't need to be at least `5.4` after this change.
